### PR TITLE
Remove yt-dlp dependency and investigate errors

### DIFF
--- a/api/Application/Services/UrlCanonicalizer.cs
+++ b/api/Application/Services/UrlCanonicalizer.cs
@@ -19,7 +19,7 @@ public interface IUrlCanonicalizer
 public class UrlCanonicalizer : IUrlCanonicalizer
 {
     private static readonly Regex YouTubeVideoRegex = new(
-        @"(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})",
+        @"(?:youtube\.com\/(?:watch\?v=|live\/|embed\/|shorts\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex TikTokVideoRegex = new(

--- a/api/Application/Services/YtDlpDownloader.cs
+++ b/api/Application/Services/YtDlpDownloader.cs
@@ -1,5 +1,7 @@
 using HumanProof.Api.Application.DTOs;
 using Microsoft.Extensions.Options;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
 
 namespace HumanProof.Api.Application.Services;
 
@@ -8,117 +10,108 @@ namespace HumanProof.Api.Application.Services;
 /// </summary>
 public sealed class YtDlpDownloader : IMediaDownloader
 {
-    private readonly IProcessRunner _processRunner;
+    private readonly IProcessRunner _processRunner; // retained but unused in MVP HTTP mode
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly DownloaderOptions _options;
     private readonly ILogger<YtDlpDownloader> _logger;
 
     public YtDlpDownloader(
         IProcessRunner processRunner,
+        IHttpClientFactory httpClientFactory,
         IOptions<DownloaderOptions> options,
         ILogger<YtDlpDownloader> logger)
     {
         _processRunner = processRunner;
+        _httpClientFactory = httpClientFactory;
         _options = options.Value;
         _logger = logger;
     }
 
     public async Task<string> DownloadAsync(string url, string? userCookies = null, CancellationToken ct = default)
     {
-        string? tempCookiesPath = null;
-        
         try
         {
-            _logger.LogInformation("Starting download for URL: {Url}", url);
+            _logger.LogInformation("Starting HTTP download for URL: {Url}", url);
 
             // Ensure temp directory exists
             Directory.CreateDirectory(_options.TempDir);
 
-            // Generate safe filename
-            var safeName = Guid.NewGuid().ToString("N");
-            var outputTemplate = Path.Combine(_options.TempDir, $"{safeName}.%(ext)s");
-
-            // Build yt-dlp command
-            var args = $"--no-playlist -f \"bv*+ba/b\" --merge-output-format mp4 -o \"{outputTemplate}\" \"{url}\"";
-            
-            // Priority 1: User-supplied cookies (if provided)
+            // We do not support authenticated downloads in MVP HTTP mode
             if (!string.IsNullOrWhiteSpace(userCookies))
             {
-                tempCookiesPath = Path.Combine(_options.TempDir, $"cookies-{safeName}.txt");
-                await File.WriteAllTextAsync(tempCookiesPath, userCookies, ct);
-                args = $"--cookies \"{tempCookiesPath}\" {args}";
-                _logger.LogInformation("Using user-supplied cookies for this request");
+                _logger.LogWarning("Ignoring user-supplied cookies in HTTP download mode");
             }
-            // Priority 2: Server-configured cookies (fallback)
-            else
+
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(Math.Max(5, _options.TimeoutSeconds));
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("video/*"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/octet-stream"));
+
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (!response.IsSuccessStatusCode)
             {
-                var cookiesPath = Environment.GetEnvironmentVariable("YTDLP_COOKIES");
-                if (!string.IsNullOrEmpty(cookiesPath) && File.Exists(cookiesPath))
+                throw new InvalidOperationException($"HTTP download failed: {(int)response.StatusCode} {response.ReasonPhrase}");
+            }
+
+            var contentType = response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
+            var ext = GuessExtension(url, contentType);
+            var safeName = $"dl-{Guid.NewGuid():N}{ext}";
+            var outputPath = Path.Combine(_options.TempDir, safeName);
+
+            await using var responseStream = await response.Content.ReadAsStreamAsync(ct);
+            await using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+
+            long totalWritten = 0;
+            var buffer = new byte[81920];
+            int read;
+            while ((read = await responseStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct)) > 0)
+            {
+                totalWritten += read;
+                if (totalWritten > _options.MaxBytes)
                 {
-                    args = $"--cookies \"{cookiesPath}\" {args}";
-                    _logger.LogInformation("Using server cookies from: {CookiesPath}", cookiesPath);
+                    try { fileStream.Close(); File.Delete(outputPath); } catch { /* ignore */ }
+                    throw new InvalidOperationException($"File too large: {totalWritten} bytes (max: {_options.MaxBytes})");
                 }
-                else
-                {
-                    _logger.LogDebug("No cookies configured (neither user-supplied nor server YTDLP_COOKIES)");
-                }
+                await fileStream.WriteAsync(buffer.AsMemory(0, read), ct);
             }
 
-            _logger.LogDebug("Running yt-dlp with args: {Args}", args);
-
-            var (exitCode, stdout, stderr) = await _processRunner.RunAsync(
-                _options.Bin, 
-                args, 
-                _options.TimeoutSeconds, 
-                ct);
-
-            if (exitCode != 0)
-            {
-                _logger.LogError("yt-dlp failed with exit code {ExitCode}. Stderr: {Stderr}", exitCode, stderr);
-                throw new InvalidOperationException($"yt-dlp failed: {stderr}");
-            }
-
-            // Find the downloaded file
-            var downloadedFiles = Directory.GetFiles(_options.TempDir, $"{safeName}.*");
-            var downloadedFile = downloadedFiles.FirstOrDefault();
-
-            if (downloadedFile == null)
-            {
-                _logger.LogError("Downloaded file not found. Expected pattern: {Pattern}", $"{safeName}.*");
-                throw new FileNotFoundException($"Download output not found for {safeName}");
-            }
-
-            // Check file size
-            var fileInfo = new FileInfo(downloadedFile);
-            if (fileInfo.Length > _options.MaxBytes)
-            {
-                _logger.LogError("Downloaded file too large: {Size} bytes (max: {MaxBytes})", fileInfo.Length, _options.MaxBytes);
-                File.Delete(downloadedFile); // Clean up
-                throw new InvalidOperationException($"File too large: {fileInfo.Length} bytes (max: {_options.MaxBytes})");
-            }
-
-            _logger.LogInformation("Successfully downloaded file: {FilePath} ({Size} bytes)", downloadedFile, fileInfo.Length);
-            return downloadedFile;
+            _logger.LogInformation("Successfully downloaded file via HTTP: {FilePath} ({Size} bytes)", outputPath, totalWritten);
+            return outputPath;
         }
-        catch (Exception ex) when (!(ex is InvalidOperationException || ex is FileNotFoundException))
+        catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during download for URL: {Url}", url);
+            _logger.LogError(ex, "HTTP download error for URL: {Url}", url);
             throw new InvalidOperationException($"Download failed: {ex.Message}", ex);
         }
-        finally
+    }
+
+    private static string GuessExtension(string url, string contentType)
+    {
+        var ext = contentType.ToLowerInvariant() switch
         {
-            // Clean up temporary cookies file (user-supplied cookies only)
-            if (!string.IsNullOrEmpty(tempCookiesPath) && File.Exists(tempCookiesPath))
-            {
-                try
-                {
-                    File.Delete(tempCookiesPath);
-                    _logger.LogDebug("Cleaned up temporary cookies file: {Path}", tempCookiesPath);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to delete temporary cookies file: {Path}", tempCookiesPath);
-                }
-            }
+            "video/mp4" => ".mp4",
+            "video/webm" => ".webm",
+            "video/quicktime" => ".mov",
+            "image/jpeg" or "image/jpg" => ".jpg",
+            "image/png" => ".png",
+            "image/gif" => ".gif",
+            "image/webp" => ".webp",
+            _ => null
+        };
+        if (!string.IsNullOrEmpty(ext)) return ext;
+
+        try
+        {
+            var uri = new Uri(url);
+            var path = uri.AbsolutePath;
+            var m = Regex.Match(path, @"\.([a-zA-Z0-9]{2,5})$");
+            if (m.Success) return "." + m.Groups[1].Value.ToLowerInvariant();
         }
+        catch { /* ignore */ }
+
+        return ".bin";
     }
 }

--- a/api/Controllers/AdminController.cs
+++ b/api/Controllers/AdminController.cs
@@ -12,16 +12,13 @@ namespace HumanProof.Api.Controllers;
 public class AdminController : ControllerBase
 {
     private readonly ISettingsService _settingsService;
-    private readonly IYouTubeVideoHasher _youtubeHasher;
     private readonly ILogger<AdminController> _logger;
 
     public AdminController(
         ISettingsService settingsService,
-        IYouTubeVideoHasher youtubeHasher,
         ILogger<AdminController> logger)
     {
         _settingsService = settingsService;
-        _youtubeHasher = youtubeHasher;
         _logger = logger;
     }
 
@@ -87,58 +84,7 @@ public class AdminController : ControllerBase
         return Ok(new { message = $"Setting '{key}' updated successfully", key, value = request.Value });
     }
 
-    /// <summary>
-    /// Test if YouTube cookies are valid by attempting to get duration of a public video
-    /// </summary>
-    [HttpPost("youtube/test-cookies")]
-    [ProducesResponseType(typeof(TestCookiesResult), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<TestCookiesResult>> TestYouTubeCookies()
-    {
-        _logger.LogInformation("Admin: Testing YouTube cookies");
-
-        // Use a known public YouTube video for testing (Rick Astley - Never Gonna Give You Up)
-        const string TEST_VIDEO_ID = "dQw4w9WgXcQ";
-
-        try
-        {
-            // Just try to get the duration - this will validate cookies without downloading
-            var result = await _youtubeHasher.HashVideoAsync(TEST_VIDEO_ID);
-            
-            // If we got here, cookies work
-            _logger.LogInformation("✅ YouTube cookies test passed");
-            
-            return Ok(new TestCookiesResult
-            {
-                Success = true,
-                Message = "Cookies are valid and working",
-                TestVideoId = TEST_VIDEO_ID,
-                Duration = result.DurationSeconds
-            });
-        }
-        catch (YouTubeCookieException ex)
-        {
-            _logger.LogWarning(ex, "❌ YouTube cookies test failed - authentication error");
-            
-            return Ok(new TestCookiesResult
-            {
-                Success = false,
-                Message = "Cookies are invalid or expired",
-                Error = ex.Message
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "❌ YouTube cookies test failed - unexpected error");
-            
-            return Ok(new TestCookiesResult
-            {
-                Success = false,
-                Message = "Test failed with unexpected error",
-                Error = ex.Message
-            });
-        }
-    }
+    // YouTube cookies test removed for MVP (thumbnail-only)
 }
 
 /// <summary>

--- a/api/Controllers/ProofsController.cs
+++ b/api/Controllers/ProofsController.cs
@@ -33,7 +33,7 @@ public class ProofsController : ControllerBase
     private readonly IMediaDownloader _downloader;
     private readonly IYouTubeThumbnailDownloader _thumbnailDownloader;
     private readonly ISettingsService _settingsService;
-    private readonly IYouTubeVideoHasher _youtubeVideoHasher;
+    // private readonly IYouTubeVideoHasher _youtubeVideoHasher; // Removed for MVP
     private readonly ILogger<ProofsController> _logger;
     private readonly IOptionsSnapshot<FeatureFlags> _featureFlags;
     private readonly DevC2paSigner _devC2paSigner;
@@ -54,7 +54,7 @@ public class ProofsController : ControllerBase
         IMediaDownloader downloader,
         IYouTubeThumbnailDownloader thumbnailDownloader,
         ISettingsService settingsService,
-        IYouTubeVideoHasher youtubeVideoHasher,
+        // IYouTubeVideoHasher youtubeVideoHasher,
         ILogger<ProofsController> logger,
         IOptionsSnapshot<FeatureFlags> featureFlags,
         DevC2paSigner devC2paSigner,
@@ -74,7 +74,7 @@ public class ProofsController : ControllerBase
         _downloader = downloader;
         _thumbnailDownloader = thumbnailDownloader;
         _settingsService = settingsService;
-        _youtubeVideoHasher = youtubeVideoHasher;
+        // _youtubeVideoHasher = youtubeVideoHasher;
         _logger = logger;
         _featureFlags = featureFlags;
         _devC2paSigner = devC2paSigner;
@@ -188,49 +188,12 @@ public class ProofsController : ControllerBase
                 var videoId = videoIdMatch.Groups[1].Value; // Preserve original case
                 
                 // Check admin-configured verification mode
-                var verificationMode = await _settingsService.GetSettingAsync("YOUTUBE_VERIFICATION_MODE") ?? "thumbnail";
-                _logger.LogInformation("🎬 YouTube verification mode: {Mode} (video ID: {VideoId})", verificationMode, videoId);
-                
-                if (verificationMode == "full_video")
-                {
-                    try
-                    {
-                        _logger.LogInformation("🎥 Attempting full video hash for YouTube");
-                        var hashResult = await _youtubeVideoHasher.HashVideoAsync(videoId);
-                        downloadedFilePath = hashResult.FilePath;
-                        fileInfo = new FileInfo(downloadedFilePath);
-                        useFullVideo = true;
-                        _logger.LogInformation("✅ Full video hash completed. File: {FilePath}, Size: {Size} bytes, Truncated: {Truncated}", 
-                            downloadedFilePath, fileInfo.Length, hashResult.WasTruncated);
-                    }
-                    catch (YouTubeCookieException ex)
-                    {
-                        _logger.LogError(ex, "🚫 Cookie authentication failed, falling back to thumbnail mode");
-                        // Will fall through to thumbnail mode below
-                        downloadedFilePath = await _thumbnailDownloader.DownloadThumbnailAsync(videoId);
-                        fileInfo = new FileInfo(downloadedFilePath);
-                        _logger.LogInformation("✅ Thumbnail downloaded successfully (fallback). File: {FilePath}, Size: {Size} bytes", 
-                            downloadedFilePath, fileInfo.Length);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "❌ Full video hash failed, falling back to thumbnail mode");
-                        // Will fall through to thumbnail mode below
-                        downloadedFilePath = await _thumbnailDownloader.DownloadThumbnailAsync(videoId);
-                        fileInfo = new FileInfo(downloadedFilePath);
-                        _logger.LogInformation("✅ Thumbnail downloaded successfully (fallback). File: {FilePath}, Size: {Size} bytes", 
-                            downloadedFilePath, fileInfo.Length);
-                    }
-                }
-                else
-                {
-                    // Thumbnail mode
-                    _logger.LogInformation("📸 Downloading YouTube thumbnail for reliable verification");
-                    downloadedFilePath = await _thumbnailDownloader.DownloadThumbnailAsync(videoId);
-                    fileInfo = new FileInfo(downloadedFilePath);
-                    _logger.LogInformation("✅ Thumbnail downloaded successfully. File: {FilePath}, Size: {Size} bytes", 
-                        downloadedFilePath, fileInfo.Length);
-                }
+                // Force thumbnail mode for MVP to avoid yt-dlp dependency
+                _logger.LogInformation("📸 Downloading YouTube thumbnail for reliable verification");
+                downloadedFilePath = await _thumbnailDownloader.DownloadThumbnailAsync(videoId);
+                fileInfo = new FileInfo(downloadedFilePath);
+                _logger.LogInformation("✅ Thumbnail downloaded successfully. File: {FilePath}, Size: {Size} bytes", 
+                    downloadedFilePath, fileInfo.Length);
             }
             else
             {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -114,9 +114,8 @@ try
     builder.Services.AddScoped<IUrlCanonicalizer, UrlCanonicalizer>();
     builder.Services.AddSingleton<IVerificationStatusTracker, VerificationStatusTracker>();
     
-    // Register Settings and YouTube Video Hasher services
+    // Register Settings service
     builder.Services.AddScoped<ISettingsService, SettingsService>();
-    builder.Services.AddScoped<IYouTubeVideoHasher, YouTubeVideoHasher>();
 
     // Configure C2PA options
     builder.Services.Configure<C2paOptions>(builder.Configuration.GetSection("C2pa"));
@@ -315,24 +314,7 @@ try
     {
         var toolVersions = new Dictionary<string, string>();
 
-        try
-        {
-            // Get yt-dlp version
-            var ytDlpProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "yt-dlp",
-                Arguments = "--version",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = true
-            });
-            if (ytDlpProcess != null)
-            {
-                ytDlpProcess.WaitForExit(5000);
-                toolVersions["yt-dlp"] = ytDlpProcess.StandardOutput.ReadToEnd().Trim();
-            }
-        }
-        catch { toolVersions["yt-dlp"] = "unknown"; }
+        // yt-dlp deprecated for MVP; no version check
 
         try
         {
@@ -367,28 +349,7 @@ try
         var toolVersions = new Dictionary<string, string>();
         var allToolsWorking = true;
 
-        try
-        {
-            // Get yt-dlp version
-            var ytDlpProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "yt-dlp",
-                Arguments = "--version",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = true
-            });
-            if (ytDlpProcess != null)
-            {
-                ytDlpProcess.WaitForExit(5000);
-                toolVersions["yt-dlp"] = ytDlpProcess.StandardOutput.ReadToEnd().Trim();
-            }
-        }
-        catch
-        {
-            toolVersions["yt-dlp"] = "unknown";
-            allToolsWorking = false;
-        }
+        // yt-dlp deprecated for MVP; no version check
 
         try
         {


### PR DESCRIPTION
Remove `yt-dlp` dependency and force YouTube URL verification to use thumbnail-only mode to prevent `500` errors caused by YouTube's bot detection.

The previous implementation attempted to use `yt-dlp` for full video hashing, which often failed from datacenter IPs without specific YouTube cookies due to bot detection, resulting in `500` errors for users. By switching to thumbnail-only verification for YouTube and a generic HTTP downloader for other media, we eliminate this external dependency and improve reliability for MVP.

---
<a href="https://cursor.com/background-agent?bcId=bc-a00d4def-550d-46ff-b3bd-6a879a580e98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a00d4def-550d-46ff-b3bd-6a879a580e98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

