### PR TITLE
Fix yt-dlp youtube url processing error

### DIFF
--- a/api/Application/Services/UrlCanonicalizer.cs
+++ b/api/Application/Services/UrlCanonicalizer.cs
@@ -19,7 +19,7 @@ public interface IUrlCanonicalizer
 public class UrlCanonicalizer : IUrlCanonicalizer
 {
     private static readonly Regex YouTubeVideoRegex = new(
-        @"(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})",
+        @"(?:youtube\.com/(?:watch\?v=|live/|shorts/|embed/)|youtu\.be/)([a-zA-Z0-9_-]{11})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex TikTokVideoRegex = new(

--- a/api/Controllers/ProofsController.cs
+++ b/api/Controllers/ProofsController.cs
@@ -176,8 +176,9 @@ public class ProofsController : ControllerBase
             
             if (platform == MediaPlatform.YouTube)
             {
-                // Extract video ID for YouTube handling
-                var videoIdMatch = Regex.Match(request.Url, @"(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})");
+                // Extract video ID for YouTube handling - supports all common YouTube URL formats
+                // Matches: /watch?v=ID, /live/ID, /shorts/ID, /embed/ID, youtu.be/ID
+                var videoIdMatch = Regex.Match(request.Url, @"(?:youtube\.com/(?:watch\?v=|live/|shorts/|embed/)|youtu\.be/)([a-zA-Z0-9_-]{11})");
                 if (!videoIdMatch.Success)
                 {
                     throw new InvalidOperationException($"Could not extract YouTube video ID from URL: {request.Url}");


### PR DESCRIPTION
Update YouTube URL regex patterns to support `/live/`, `/shorts/`, and `/embed/` formats.

The previous regex only matched `/watch?v=` and `youtu.be/` URLs, causing `/live/` URLs to be misidentified and processed by `yt-dlp`, leading to "Sign in to confirm you’re not a bot" errors. This fix ensures all common YouTube URL formats are correctly handled for thumbnail extraction.

---
<a href="https://cursor.com/background-agent?bcId=bc-393fd6bc-2649-4aa7-89ce-4ff8a2885de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-393fd6bc-2649-4aa7-89ce-4ff8a2885de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

