### PR TITLE
Fix yt-dlp youtube url processing error

### DIFF
--- a/api/Application/Services/UrlCanonicalizer.cs
+++ b/api/Application/Services/UrlCanonicalizer.cs
@@ -18,8 +18,16 @@ public interface IUrlCanonicalizer
 
 public class UrlCanonicalizer : IUrlCanonicalizer
 {
+    // Matches common YouTube URL forms and captures the 11-char video ID
+    // Supported:
+    // - https://www.youtube.com/watch?v=VIDEOID
+    // - https://youtu.be/VIDEOID
+    // - https://www.youtube.com/shorts/VIDEOID
+    // - https://www.youtube.com/live/VIDEOID
+    // - https://www.youtube.com/embed/VIDEOID
+    // - https://www.youtube.com/v/VIDEOID
     private static readonly Regex YouTubeVideoRegex = new(
-        @"(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})",
+        @"(?:youtube\.com/(?:watch\?v=|shorts/|live/|embed/|v/)|youtu\.be/)([a-zA-Z0-9_-]{11})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex TikTokVideoRegex = new(

--- a/api/Application/Services/YouTubeThumbnailDownloader.cs
+++ b/api/Application/Services/YouTubeThumbnailDownloader.cs
@@ -33,11 +33,17 @@ public class YouTubeThumbnailDownloader : IYouTubeThumbnailDownloader
         _logger.LogInformation("Downloading YouTube thumbnail for video: {VideoId}", videoId);
 
         // YouTube thumbnail URLs (in order of quality preference)
+        // Include live variants and additional fallbacks for broader coverage
         var thumbnailUrls = new[]
         {
-            $"https://img.youtube.com/vi/{videoId}/maxresdefault.jpg",  // 1920x1080
-            $"https://img.youtube.com/vi/{videoId}/sddefault.jpg",      // 640x480
-            $"https://img.youtube.com/vi/{videoId}/hqdefault.jpg"       // 480x360
+            $"https://img.youtube.com/vi/{videoId}/maxresdefault.jpg",        // 1920x1080
+            $"https://img.youtube.com/vi/{videoId}/maxresdefault_live.jpg",   // Live stream variant
+            $"https://img.youtube.com/vi/{videoId}/sddefault.jpg",            // 640x480
+            $"https://img.youtube.com/vi/{videoId}/sddefault_live.jpg",       // Live stream variant
+            $"https://img.youtube.com/vi/{videoId}/hqdefault.jpg",            // 480x360
+            $"https://img.youtube.com/vi/{videoId}/hqdefault_live.jpg",       // Live stream variant
+            $"https://img.youtube.com/vi/{videoId}/mqdefault.jpg",            // 320x180
+            $"https://img.youtube.com/vi/{videoId}/default.jpg"               // 120x90
         };
 
         Exception? lastException = null;

--- a/api/Controllers/ProofsController.cs
+++ b/api/Controllers/ProofsController.cs
@@ -177,7 +177,10 @@ public class ProofsController : ControllerBase
             if (platform == MediaPlatform.YouTube)
             {
                 // Extract video ID for YouTube handling
-                var videoIdMatch = Regex.Match(request.Url, @"(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})");
+                var videoIdMatch = Regex.Match(
+                    request.Url,
+                    @"(?:youtube\.com/(?:watch\?v=|shorts/|live/|embed/|v/)|youtu\.be/)([a-zA-Z0-9_-]{11})",
+                    RegexOptions.IgnoreCase);
                 if (!videoIdMatch.Success)
                 {
                     throw new InvalidOperationException($"Could not extract YouTube video ID from URL: {request.Url}");


### PR DESCRIPTION
Expand YouTube URL pattern recognition and add live thumbnail fallbacks to prevent `yt-dlp` errors for YouTube Live, Shorts, and Embed links.

Previously, YouTube Live/Shorts/Embed URLs were not correctly identified, causing the system to fall back to `yt-dlp`, which resulted in "Sign in to confirm you’re not a bot" errors. This change ensures these URLs are now routed to the thumbnail extraction process, bypassing `yt-dlp`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b97acb4-b94c-49a5-ba5c-b955a781862b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b97acb4-b94c-49a5-ba5c-b955a781862b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

